### PR TITLE
ci/feat: pr and commit links for release notes

### DIFF
--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -43,12 +43,9 @@ jobs:
           LATEST_TAG="${LATEST_TAG#v}"
           echo "::set-output name=tag::$LATEST_TAG"
 
-      - name: Set release notes
-        id: set-body
+      - name: Create release notes
         run: |
-          touch body.md
-          git log --after="${{ steps.set-date.outputs.yesterday }} 00:00" --before="${{ steps.set-date.outputs.today }} 00:00" --oneline >> body.md
-          cat body.md
+          ./scripts/write-release-notes.sh sway
 
       - name: Create Release
         id: create-release

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -44,12 +44,9 @@ jobs:
           LATEST_TAG="${LATEST_TAG#v}"
           echo "::set-output name=tag::$LATEST_TAG"
 
-      - name: Set release notes
-        id: set-body
+      - name: Create release notes
         run: |
-          touch body.md
-          git log --after="${{ steps.set-date.outputs.yesterday }} 00:00" --before="${{ steps.set-date.outputs.today }} 00:00" --oneline >> body.md
-          cat body.md
+          ./scripts/write-release-notes.sh fuel-core
 
       - name: Create Release
         id: create-release

--- a/.github/workflows/scripts/write-release-notes.sh
+++ b/.github/workflows/scripts/write-release-notes.sh
@@ -1,0 +1,18 @@
+touch body.md
+touch body.tmp
+git log --after="${{ steps.set-date.outputs.yesterday }} 00:00" --before="${{ steps.set-date.outputs.today }} 00:00" --oneline >> body.tmp
+echo "Generating release notes from repo: ${1}"
+
+while read -r line; do
+	  commit=$(echo "$line" | cut -d ' ' -f1)
+	  pr=$(echo "$line" | cut -d '#' -f2 | rev | cut -c2- | rev)
+	  description=$(echo "$line" | cut -d ' ' -f2- | rev | cut -d ' ' -f2- | rev)
+
+	  commit_url="https://github.com/FuelLabs/${1}/commit/${commit}"
+	  pr_url="https://github.com/FuelLabs/${1}/pull/${pr}"
+
+	  echo "- [${commit}](${commit_url}) ${description} [#${pr}](${pr_url})" >> body.md
+done <body.tmp
+
+echo "" >> body.md
+rm body.tmp


### PR DESCRIPTION
The workflow current does `git log --oneline` to fetch commits to master, and this is just text. This PR just formats the text so that they link directly to the PRs/commits, like so:

Example:

- [4fe1949e6](https://github.com/FuelLabs/sway/commit/4fe1949e6) Use zero and one registers instead of 0/1 immediates [#2621](https://github.com/FuelLabs/sway/pull/2621)
- [1549bab1c](https://github.com/FuelLabs/sway/commit/1549bab1c) Fix `storage` blocks [#2618](https://github.com/FuelLabs/sway/pull/2618)
- [f7b346eb4](https://github.com/FuelLabs/sway/commit/f7b346eb4) fix: ForwardSlash span collection [#2625](https://github.com/FuelLabs/sway/pull/2625)
