### PR TITLE
Remove hyphen from dates to comply with semver

### DIFF
--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Set current date
         id: set-date
         run: |
-          TODAY=$(date +'%Y-%m-%d')
+          TODAY=$(date +'%Y%m%d')
           echo "::set-output name=today::$TODAY"
-          echo "::set-output name=yesterday::$(date --date="$TODAY -1 day" +'%Y-%m-%d')"
+          echo "::set-output name=yesterday::$(date --date="$TODAY -1 day" +'%Y%m%d')"
 
       - name: Set commit hash
         id: set-commit-hash

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Set current date
         id: set-date
         run: |
-          TODAY=$(date +'%Y-%m-%d')
+          TODAY=$(date +'%Y%m%d')
           echo "::set-output name=today::$TODAY"
-          echo "::set-output name=yesterday::$(date --date="$TODAY -1 day" +'%Y-%m-%d')"
+          echo "::set-output name=yesterday::$(date --date="$TODAY -1 day" +'%Y%m%d')"
 
       - name: Set commit hash
         id: set-commit-hash


### PR DESCRIPTION
One last change to remove hyphens from dates to comply with semver: https://semver.org/#spec-item-10

> Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version...

The previous versions were __not__ semver compliant, since the build metadata was (example) `nightly.2022-09-15.abcdefg` - the date should not be separated by hyphens.