### PR TITLE
set git short sha length to 10

### DIFF
--- a/.github/workflows/nightly-forc-client-release.yml
+++ b/.github/workflows/nightly-forc-client-release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set commit hash
         id: set-commit-hash
         run: |
-          echo "::set-output name=commit_hash::$(git rev-parse --short HEAD)"
+          echo "::set-output name=commit_hash::$(git rev-parse --short=12 HEAD)"
 
       - name: Set tag 
         id: set-tag

--- a/.github/workflows/nightly-forc-client-release.yml
+++ b/.github/workflows/nightly-forc-client-release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set commit hash
         id: set-commit-hash
         run: |
-          echo "::set-output name=commit_hash::$(git rev-parse --short=12 HEAD)"
+          echo "::set-output name=commit_hash::$(git rev-parse --short=10 HEAD)"
 
       - name: Set tag 
         id: set-tag

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set commit hash
         id: set-commit-hash
         run: |
-          echo "::set-output name=commit_hash::$(git rev-parse --short HEAD)"
+          echo "::set-output name=commit_hash::$(git rev-parse --short=12 HEAD)"
 
       - name: Set tag 
         id: set-tag

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set commit hash
         id: set-commit-hash
         run: |
-          echo "::set-output name=commit_hash::$(git rev-parse --short=12 HEAD)"
+          echo "::set-output name=commit_hash::$(git rev-parse --short=10 HEAD)"
 
       - name: Set tag 
         id: set-tag

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -35,13 +35,13 @@ jobs:
         id: set-date
         run: |
           TODAY=$(date +'%Y%m%d')
-          echo "::set-output name=today::$TODAY"
+          ecto "::set-output name=today::$TODAY"
           echo "::set-output name=yesterday::$(date --date="$TODAY -1 day" +'%Y%m%d')"
 
       - name: Set commit hash
         id: set-commit-hash
         run: |
-          echo "::set-output name=commit_hash::$(git rev-parse --short HEAD)"
+          echo "::set-output name=commit_hash::$(git rev-parse --short=12 HEAD)"
 
       - name: Set tag 
         id: set-tag

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -35,7 +35,7 @@ jobs:
         id: set-date
         run: |
           TODAY=$(date +'%Y%m%d')
-          ecto "::set-output name=today::$TODAY"
+          echo "::set-output name=today::$TODAY"
           echo "::set-output name=yesterday::$(date --date="$TODAY -1 day" +'%Y%m%d')"
 
       - name: Set commit hash

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set commit hash
         id: set-commit-hash
         run: |
-          echo "::set-output name=commit_hash::$(git rev-parse --short=12 HEAD)"
+          echo "::set-output name=commit_hash::$(git rev-parse --short=10 HEAD)"
 
       - name: Set tag 
         id: set-tag


### PR DESCRIPTION
From the git book:

> Generally, eight to ten characters are more than enough to be unique within a project. For example, as of February 2019, the Linux kernel (which is a fairly sizable project) has over 875,000 commits and almost seven million objects in its object database, with no two objects whose SHA-1s are identical in the first 12 characters.

 source: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1

Technically its unlikely we run into hash collisions, but its still nice to fix our commit hash within the build metadata to a sensible length. In this case I simply chose the maximum of the recommended 8-10 characters.