### PR TITLE
fix: build with --locked, remove forc-doc installation

### DIFF
--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -116,13 +116,7 @@ jobs:
 
       - name: Build forc binaries
         run: |
-          cross build --profile=release --target ${{ matrix.job.target }} --bins
-
-      - name: Install forc-doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --profile=release --path ./forc-plugins/forc-doc
+          cross build --profile=release --locked --target ${{ matrix.job.target }} --bins
 
       - name: Prep Assets
         id: prep_assets


### PR DESCRIPTION
mistakenly installed and built `forc-doc` twice: https://github.com/FuelLabs/sway-nightly-binaries/actions/runs/4039351047/jobs/6944001587

 also added `--locked` to `cross build`.