### PR TITLE
fix: add `wasm32` to installed toolchains for fuel-core nightly builds

### DIFF
--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -109,13 +109,8 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: ${{ matrix.job.target }}
+          target: ${{ matrix.job.target }},"wasm32-unknown-unknown"
           override: true
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1.1.2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-edit
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Removes `protoc` which is not required anymore and adds `wasm32` to fix builds failures. Thanks @xgreenx :)