### PR TITLE
fix: Update rust version for fuel-core

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -89,13 +89,11 @@ jobs:
     steps:
     - name: Ensure release-forc succeeded
       run: |
-        if [ 
-          "${{ needs.create-release.result }}" != "success"
-          || "${{ needs.release-forc.result }}" != "success"
-          || "${{ needs.release-fuel-core.result }}" != "success"
-          || "${{ needs.release-forc-explorer.result }}" != "success"
-          || "${{ needs.release-forc-wallet }}" != "success"
-        ]; then
+        if [ "${{ needs.create-release.result }}" != "success" ] || \
+          [ "${{ needs.release-forc.result }}" != "success" ] || \
+          [ "${{ needs.release-fuel-core.result }}" != "success" ] || \
+          [ "${{ needs.release-forc-explorer.result }}" != "success" ] || \
+          [ "${{ needs.release-forc-wallet.result }}" != "success" ]; then
           echo "Workflow failed. Exiting..."
           exit 1
         else

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -15,7 +15,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.76.0
+  RUST_VERSION: 1.75.0
 
 jobs:
   prepare-release:


### PR DESCRIPTION
The CI builds have been failing for x86 macos because of this error:

```
info: note that the toolchain '1.75.0-aarch64-apple-darwin' is currently in use (overridden by '/Users/runner/work/sway-nightly-binaries/sway-nightly-binaries/rust-toolchain.toml')
...
error[E0463]: can't find crate for `core`
  |
  = note: the `x86_64-apple-darwin` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-apple-darwin`
```

This is because the rust version doesn't match the version in the newly added toolchain toml file in fuel core: https://github.com/FuelLabs/fuel-core/blob/master/rust-toolchain.toml

So the `x86_64-apple-darwin` is installed for the wrong version, and not used at build time. I believe by fixing the version to match what's in fuel-core, the target will be installed and the build should succeed ([link](https://github.com/FuelLabs/sway-nightly-binaries/actions/runs/9604549605))

Also updated the CI step for slack notifications - it wasn't working because of a syntax error.