### PR TITLE
ci: only notify on the top level workflow

### DIFF
--- a/.github/workflows/nightly-forc-explorer-release.yml
+++ b/.github/workflows/nightly-forc-explorer-release.yml
@@ -1,4 +1,4 @@
-name: Forc Explorer Release (nightly) 
+name: Forc Explorer Release (nightly)
 
 on:
   workflow_dispatch:
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "::set-output name=commit_hash::$(git rev-parse --short=10 HEAD)"
 
-      - name: Set tag 
+      - name: Set tag
         id: set-tag
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0)
@@ -86,9 +86,8 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
-          key: "${{ matrix.job.target }}"
+          key: '${{ matrix.job.target }}'
 
-            
       - name: Install cargo-edit
         uses: actions-rs/cargo@v1
         with:
@@ -105,7 +104,7 @@ jobs:
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cross
-          cache-key: "${{ matrix.job.target }}"
+          cache-key: '${{ matrix.job.target }}'
 
       - name: Build forc-explore
         run: |
@@ -152,16 +151,3 @@ jobs:
           asset_path: ./${{ env.ZIP_FILE_NAME }}
           asset_name: ${{ env.ZIP_FILE_NAME }}
           asset_content_type: application/gzip
-
-      - name: Notify if Job Fails
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>"
-          footer: ""
-          notify_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_TOOLING }}

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -1,4 +1,4 @@
-name: Forc Release (nightly) 
+name: Forc Release (nightly)
 
 on:
   workflow_dispatch:
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "::set-output name=commit_hash::$(git rev-parse --short=10 HEAD)"
 
-      - name: Set tag 
+      - name: Set tag
         id: set-tag
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0)
@@ -94,7 +94,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
-          key: "${{ matrix.job.target }}"
+          key: '${{ matrix.job.target }}'
 
       - name: Install cargo-edit
         uses: actions-rs/cargo@v1
@@ -112,7 +112,7 @@ jobs:
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cross
-          cache-key: "${{ matrix.job.target }}"
+          cache-key: '${{ matrix.job.target }}'
 
       - name: Build forc binaries
         run: |
@@ -142,16 +142,3 @@ jobs:
           asset_path: ./${{ env.ZIP_FILE_NAME }}
           asset_name: ${{ env.ZIP_FILE_NAME }}
           asset_content_type: application/gzip
-
-      - name: Notify if Job Fails
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>"
-          footer: ""
-          notify_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_TOOLING }}

--- a/.github/workflows/nightly-forc-wallet-release.yml
+++ b/.github/workflows/nightly-forc-wallet-release.yml
@@ -1,4 +1,4 @@
-name: Forc Wallet Release (nightly) 
+name: Forc Wallet Release (nightly)
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
         type: string
       date:
         required: true
-        type: string  
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "::set-output name=commit_hash::$(git rev-parse --short=10 HEAD)"
 
-      - name: Set tag 
+      - name: Set tag
         id: set-tag
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0)
@@ -85,9 +85,8 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
-          key: "${{ matrix.job.target }}"
+          key: '${{ matrix.job.target }}'
 
-            
       - name: Install cargo-edit
         uses: actions-rs/cargo@v1
         with:
@@ -104,7 +103,7 @@ jobs:
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cross
-          cache-key: "${{ matrix.job.target }}"
+          cache-key: '${{ matrix.job.target }}'
 
       - name: Build forc-wallet
         run: |
@@ -151,16 +150,3 @@ jobs:
           asset_path: ./${{ env.ZIP_FILE_NAME }}
           asset_name: ${{ env.ZIP_FILE_NAME }}
           asset_content_type: application/gzip
-
-      - name: Notify if Job Fails
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>"
-          footer: ""
-          notify_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_TOOLING }}

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           echo "::set-output name=commit_hash::$(git rev-parse --short=10 HEAD)"
 
-      - name: Set tag 
+      - name: Set tag
         id: set-tag
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0)
@@ -151,7 +151,6 @@ jobs:
           aarch64-linux-gnu-strip \
           /target/aarch64-unknown-linux-gnu/release/fuel-core
 
-
       - name: Strip release binary mac
         if: matrix.job.os == 'macos-latest'
         run: strip -x "target/${{ matrix.job.target }}/release/fuel-core"
@@ -178,16 +177,3 @@ jobs:
           asset_path: ./${{ env.ZIP_FILE_NAME }}
           asset_name: ${{ env.ZIP_FILE_NAME }}
           asset_content_type: application/gzip
-
-      - name: Notify if Job Fails
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>"
-          footer: ""
-          notify_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_TOOLING }}


### PR DESCRIPTION
The previous setup didn't work because the notification action only works on linux and the job was part of an OS matrix. It should be sufficient to run the job only on `create-release` which depends on the others.