### PR TITLE
ci: add always() to monitor-release job

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -91,6 +91,7 @@ jobs:
         release-forc-wallet,
       ]
     runs-on: ubuntu-latest
+    if: always()
 
     steps:
       - name: Ensure release-forc succeeded


### PR DESCRIPTION
This job previously only ran if everything succeeded, which was not the intention. Adding `always()` so it will not be skipped after a failure.