### PR TITLE
chore: swap deprecated actions/upload-release-assets to softprops/action-gh-release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,28 +56,24 @@ jobs:
     needs: create-release
     uses: ./.github/workflows/nightly-forc-release.yml
     with:
-      upload_url: ${{ needs.create-release.outputs.upload_url }}
       date: ${{ needs.create-release.outputs.today }}
 
   release-fuel-core:
     needs: create-release
     uses: ./.github/workflows/nightly-fuel-core-release.yml
     with:
-      upload_url: ${{ needs.create-release.outputs.upload_url }}
       date: ${{ needs.create-release.outputs.today }}
 
   release-forc-explorer:
     needs: create-release
     uses: ./.github/workflows/nightly-forc-explorer-release.yml
     with:
-      upload_url: ${{ needs.create-release.outputs.upload_url }}
       date: ${{ needs.create-release.outputs.today }}
 
   release-forc-wallet:
     needs: create-release
     uses: ./.github/workflows/nightly-forc-wallet-release.yml
     with:
-      upload_url: ${{ needs.create-release.outputs.upload_url }}
       date: ${{ needs.create-release.outputs.today }}
 
   # Wait for results of called workflows

--- a/.github/workflows/nightly-forc-explorer-release.yml
+++ b/.github/workflows/nightly-forc-explorer-release.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-forc-explorer-release.yml
+++ b/.github/workflows/nightly-forc-explorer-release.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      upload_url:
-        required: true
-        type: string
       date:
         required: true
         type: string
@@ -143,11 +140,9 @@ jobs:
           tar -czvf $ZIP_FILE_NAME "$ARTIFACT"
 
       - name: Upload release archive
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ inputs.upload_url }}
-          asset_path: ./${{ env.ZIP_FILE_NAME }}
-          asset_name: ${{ env.ZIP_FILE_NAME }}
-          asset_content_type: application/gzip
+          files:
+            ${{ env.ZIP_FILE_NAME }}

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      upload_url:
-        required: true
-        type: string
       date:
         required: true
         type: string
@@ -134,11 +131,9 @@ jobs:
           tar -czvf $ZIP_FILE_NAME ./forc-binaries
 
       - name: Archive forc binaries
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ inputs.upload_url }}
-          asset_path: ./${{ env.ZIP_FILE_NAME }}
-          asset_name: ${{ env.ZIP_FILE_NAME }}
-          asset_content_type: application/gzip
+          files:
+            ${{ env.ZIP_FILE_NAME }}

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -132,6 +132,7 @@ jobs:
 
       - name: Archive forc binaries
         uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-forc-wallet-release.yml
+++ b/.github/workflows/nightly-forc-wallet-release.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      upload_url:
-        required: true
-        type: string
       date:
         required: true
         type: string
@@ -142,11 +139,9 @@ jobs:
           tar -czvf $ZIP_FILE_NAME "$ARTIFACT"
 
       - name: Upload release archive
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ inputs.upload_url }}
-          asset_path: ./${{ env.ZIP_FILE_NAME }}
-          asset_name: ${{ env.ZIP_FILE_NAME }}
-          asset_content_type: application/gzip
+          files:
+            ${{ env.ZIP_FILE_NAME }}

--- a/.github/workflows/nightly-forc-wallet-release.yml
+++ b/.github/workflows/nightly-forc-wallet-release.yml
@@ -140,6 +140,7 @@ jobs:
 
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -167,6 +167,7 @@ jobs:
 
       - name: Upload Binary Artifact
         uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      upload_url:
-        required: true
-        type: string
       date:
         required: true
         type: string
@@ -169,11 +166,9 @@ jobs:
           tar -czvf "$ZIP_FILE_NAME" "$ARTIFACT"
 
       - name: Upload Binary Artifact
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ inputs.upload_url }}
-          asset_path: ./${{ env.ZIP_FILE_NAME }}
-          asset_name: ${{ env.ZIP_FILE_NAME }}
-          asset_content_type: application/gzip
+          files:
+            ${{ env.ZIP_FILE_NAME }}


### PR DESCRIPTION
GitHub's actions/upload-release-assets is no longer maintained and seems to repeatedly break (e.g. SSLV3_ALERT_BAD_RECORD_MAC), so I suggest moving to a highly active and up to date runner.