### PR TITLE
fix: add missing `forc-submit` to list of released binaries

### DIFF
--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -128,7 +128,7 @@ jobs:
           ZIP_FILE_NAME=${{ needs.prepare-release.outputs.zip_name }}-${{ env.PLATFORM_NAME }}_${{ env.ARCH }}.tar.gz
           echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
           mkdir -pv ./forc-binaries
-          for BINARY in forc forc-fmt forc-lsp forc-deploy forc-run forc-doc forc-crypto forc-debug forc-tx; do
+          for BINARY in forc forc-fmt forc-lsp forc-deploy forc-run forc-doc forc-crypto forc-debug forc-tx forc-submit; do
             cp "target/${{ matrix.job.target }}/release/$BINARY" ./forc-binaries
           done
           tar -czvf $ZIP_FILE_NAME ./forc-binaries


### PR DESCRIPTION
closes #54.

About https://github.com/FuelLabs/fuelup/pull/689#issuecomment-2479073484. This fixes #54 by adding forc-submit to the list of released binaries.