### PR TITLE
chore: add tooling as codeowners for the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+./** @FuelLabs/tooling


### PR DESCRIPTION
Tooling maintains this repo but it doesn't own the code so reviews are not asked for automatically. This PR fixes this by adding tooling as owner of all files in this repo.