### PR TITLE
chore: use rust v1.79.0 while building fuel-core

### DIFF
--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -15,7 +15,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.75.0
+  RUST_VERSION: 1.79.0
 
 jobs:
   prepare-release:


### PR DESCRIPTION
Bumps rust version used for fuel-core builds to 1.79 to match https://github.com/FuelLabs/fuel-core/blob/master/rust-toolchain.toml.