### PR TITLE
Nightly jobs are performed on master

### DIFF
--- a/.github/workflows/nightly-forc-explorer-release.yml
+++ b/.github/workflows/nightly-forc-explorer-release.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Archive forc binaries
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-forc-wallet-release.yml
+++ b/.github/workflows/nightly-forc-wallet-release.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload Binary Artifact
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
The nightly run pushes releases on the master branch, not tags.