### PR TITLE
Enforce git tag on master releases

### DIFF
--- a/.github/workflows/nightly-forc-explorer-release.yml
+++ b/.github/workflows/nightly-forc-explorer-release.yml
@@ -139,12 +139,18 @@ jobs:
 
           tar -czvf $ZIP_FILE_NAME "$ARTIFACT"
 
+      - name: Reset and enforce tag for master releases
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git tag -d nightly-${{ inputs.date }}
+          git tag nightly-${{ inputs.date }}
+          git push --follow-tags
+
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           files:
             ${{ env.ZIP_FILE_NAME }}
-          tag_name: ${{ steps.set-tag.outputs.tag }}

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -130,12 +130,18 @@ jobs:
           done
           tar -czvf $ZIP_FILE_NAME ./forc-binaries
 
+      - name: Reset and enforce tag for master
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git tag -d nightly-${{ inputs.date }}
+          git tag nightly-${{ inputs.date }}
+          git push --follow-tags
+
       - name: Archive forc binaries
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           files:
             ${{ env.ZIP_FILE_NAME }}
-          tag_name: ${{ steps.set-tag.outputs.tag }}

--- a/.github/workflows/nightly-forc-wallet-release.yml
+++ b/.github/workflows/nightly-forc-wallet-release.yml
@@ -138,12 +138,18 @@ jobs:
 
           tar -czvf $ZIP_FILE_NAME "$ARTIFACT"
 
+      - name: Reset and enforce tag for master releases
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git tag -d nightly-${{ inputs.date }}
+          git tag nightly-${{ inputs.date }}
+          git push --follow-tags
+
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           files:
             ${{ env.ZIP_FILE_NAME }}
-          tag_name: ${{ steps.set-tag.outputs.tag }}

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -165,12 +165,18 @@ jobs:
           cp "target/${{ matrix.job.target }}/release/fuel-core" "$ARTIFACT"
           tar -czvf "$ZIP_FILE_NAME" "$ARTIFACT"
 
+      - name: Reset and enforce tag for master releases
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git tag -d nightly-${{ inputs.date }}
+          git tag nightly-${{ inputs.date }}
+          git push --follow-tags
+
       - name: Upload Binary Artifact
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           files:
             ${{ env.ZIP_FILE_NAME }}
-          tag_name: ${{ steps.set-tag.outputs.tag }}


### PR DESCRIPTION
Nightly builds are done on master, not on tags.

So let's enforce master to have a tag on build.