### PR TITLE
Create tag on repo, push to release from other repos

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -41,6 +41,14 @@ jobs:
         with:
           path: scripts
 
+      - name: Enforce tag for master releases
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git push :refs/tags/${{ steps.set-name.outputs.release_name }} || true
+          git tag -d ${{ steps.set-name.outputs.release_name }} || true
+          git tag ${{ steps.set-name.outputs.release_name }}
+          git push --tags
+
       - name: Create Release
         id: create-release
         uses: ncipollo/release-action@v1
@@ -57,24 +65,27 @@ jobs:
     uses: ./.github/workflows/nightly-forc-release.yml
     with:
       date: ${{ needs.create-release.outputs.today }}
-
+      release_name: ${{ steps.set-name.outputs.release_name }}
   release-fuel-core:
     needs: create-release
     uses: ./.github/workflows/nightly-fuel-core-release.yml
     with:
       date: ${{ needs.create-release.outputs.today }}
+      release_name: ${{ steps.set-name.outputs.release_name }}
 
   release-forc-explorer:
     needs: create-release
     uses: ./.github/workflows/nightly-forc-explorer-release.yml
     with:
       date: ${{ needs.create-release.outputs.today }}
+      release_name: ${{ steps.set-name.outputs.release_name }}
 
   release-forc-wallet:
     needs: create-release
     uses: ./.github/workflows/nightly-forc-wallet-release.yml
     with:
       date: ${{ needs.create-release.outputs.today }}
+      release_name: ${{ steps.set-name.outputs.release_name }}
 
   # Wait for results of called workflows
   monitor-release-status:

--- a/.github/workflows/nightly-forc-explorer-release.yml
+++ b/.github/workflows/nightly-forc-explorer-release.yml
@@ -7,6 +7,9 @@ on:
       date:
         required: true
         type: string
+      release_name:
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -139,13 +142,6 @@ jobs:
 
           tar -czvf $ZIP_FILE_NAME "$ARTIFACT"
 
-      - name: Reset and enforce tag for master releases
-        if: github.ref == 'refs/heads/master'
-        run: |
-          git tag -d nightly-${{ inputs.date }}
-          git tag nightly-${{ inputs.date }}
-          git push --follow-tags
-
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -154,3 +150,4 @@ jobs:
         with:
           files:
             ${{ env.ZIP_FILE_NAME }}
+          tag_name: ${{ inputs.release_name }}

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -7,6 +7,9 @@ on:
       date:
         required: true
         type: string
+      release_name:
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -130,13 +133,6 @@ jobs:
           done
           tar -czvf $ZIP_FILE_NAME ./forc-binaries
 
-      - name: Reset and enforce tag for master
-        if: github.ref == 'refs/heads/master'
-        run: |
-          git tag -d nightly-${{ inputs.date }}
-          git tag nightly-${{ inputs.date }}
-          git push --follow-tags
-
       - name: Archive forc binaries
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -145,3 +141,4 @@ jobs:
         with:
           files:
             ${{ env.ZIP_FILE_NAME }}
+          tag_name: ${{ inputs.release_name }}

--- a/.github/workflows/nightly-forc-wallet-release.yml
+++ b/.github/workflows/nightly-forc-wallet-release.yml
@@ -7,6 +7,9 @@ on:
       date:
         required: true
         type: string
+      release_name:
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -138,13 +141,6 @@ jobs:
 
           tar -czvf $ZIP_FILE_NAME "$ARTIFACT"
 
-      - name: Reset and enforce tag for master releases
-        if: github.ref == 'refs/heads/master'
-        run: |
-          git tag -d nightly-${{ inputs.date }}
-          git tag nightly-${{ inputs.date }}
-          git push --follow-tags
-
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -153,3 +149,4 @@ jobs:
         with:
           files:
             ${{ env.ZIP_FILE_NAME }}
+          tag_name: ${{ inputs.release_name }}

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -7,6 +7,9 @@ on:
       date:
         required: true
         type: string
+      release_name:
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -165,13 +168,6 @@ jobs:
           cp "target/${{ matrix.job.target }}/release/fuel-core" "$ARTIFACT"
           tar -czvf "$ZIP_FILE_NAME" "$ARTIFACT"
 
-      - name: Reset and enforce tag for master releases
-        if: github.ref == 'refs/heads/master'
-        run: |
-          git tag -d nightly-${{ inputs.date }}
-          git tag nightly-${{ inputs.date }}
-          git push --follow-tags
-
       - name: Upload Binary Artifact
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -180,3 +176,4 @@ jobs:
         with:
           files:
             ${{ env.ZIP_FILE_NAME }}
+          tag_name: ${{ inputs.release_name }}


### PR DESCRIPTION
All the previous changes today were pushing to the wrong places...

- `sway-nightly-binaries` is where each nightly release lives
- `sway-nightly-binaries` has the `nightly-` tags
- `sway-nightly-binaries` has the builds output of `forc-explorer`, `forc`, `forc-wallet`, and `fuel-core`
- All of the non-`sway-nightly-binaries` repos have their own tags in the form `vX.Y.Z`

On build, if it's `master` we need to create a tag because `softprops/action-gh-release@v2` requires one.

For all the sub-repo builds, when done, push to /this/ release target (tag).