### PR TITLE
Remove master tag now correct release name is used

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -41,14 +41,6 @@ jobs:
         with:
           path: scripts
 
-      - name: Enforce tag for master releases
-        if: github.ref == 'refs/heads/master'
-        run: |
-          git push :refs/tags/${{ steps.set-name.outputs.release_name }} || true
-          git tag -d ${{ steps.set-name.outputs.release_name }} || true
-          git tag ${{ steps.set-name.outputs.release_name }}
-          git push --tags
-
       - name: Create Release
         id: create-release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/nightly-forc-explorer-release.yml
+++ b/.github/workflows/nightly-forc-explorer-release.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Archive forc binaries
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-forc-wallet-release.yml
+++ b/.github/workflows/nightly-forc-wallet-release.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload release archive
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload Binary Artifact
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
Now that we're now using the proper release tag (i.e `create-release.outputs.release_name`) downstream, I think enforcing the branch on master isn't actually needed.

The original issue was that we were skipping builds when the tag was not set, which is why I was trying to force `master` to have a tag. But I'm now thinking that what that error message actually said was that the `tag_name` parameter to `softprops/action-gh-release@v2` was empty.

It's set now, and to the correct value `create-release.outputs.release_name`, so this should now be pushing to the correct place.