### PR TITLE
add: forc-node to nightly builds

### DIFF
--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -128,7 +128,7 @@ jobs:
           ZIP_FILE_NAME=${{ needs.prepare-release.outputs.zip_name }}-${{ env.PLATFORM_NAME }}_${{ env.ARCH }}.tar.gz
           echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
           mkdir -pv ./forc-binaries
-          for BINARY in forc forc-fmt forc-lsp forc-deploy forc-run forc-doc forc-crypto forc-debug forc-tx forc-submit forc-migrate; do
+          for BINARY in forc forc-fmt forc-lsp forc-deploy forc-run forc-doc forc-crypto forc-debug forc-tx forc-submit forc-migrate forc-node; do
             cp "target/${{ matrix.job.target }}/release/$BINARY" ./forc-binaries
           done
           tar -czvf $ZIP_FILE_NAME ./forc-binaries


### PR DESCRIPTION
Adds forc-node to the list of binaries included in nightly builds.