### PR TITLE
fix: centralize cross-compilation setup to resolve build errors

### DIFF
--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -57,22 +57,24 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
             svm_target_platform: linux-amd64
-          - os: ubuntu-latest
+            cross_image: x86_64-linux-gnu
+          - os: ubuntu-24.04
             platform: linux
             target: aarch64-unknown-linux-gnu
             arch: arm64
             svm_target_platform: linux-aarch64
-          - os: macos-latest
+            cross_image: aarch64-linux-gnu
+          - os: macos-14
             platform: darwin
             target: x86_64-apple-darwin
             arch: amd64
             svm_target_platform: macosx-amd64
-          - os: macos-latest
+          - os: macos-14
             platform: darwin
             target: aarch64-apple-darwin
             arch: arm64
@@ -83,13 +85,12 @@ jobs:
         with:
           repository: fuellabs/sway
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Setup cross build environment
+        uses: ./.github/workflows/setup-cross-build.yml
         with:
-          profile: minimal
-          toolchain: stable
           target: ${{ matrix.job.target }}
-          override: true
+          cross_image: ${{ matrix.job.cross_image }}
+          os: ${{ matrix.job.os }}
 
       - uses: Swatinem/rust-cache@v1
         with:

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -85,31 +85,13 @@ jobs:
         with:
           repository: fuellabs/fuel-core
 
-      - name: Set up Docker Buildx
-        if: matrix.job.cross_image
-        uses: docker/setup-buildx-action@v1
-
-      - name: Setup custom cross env ${{ matrix.job.cross_image }}
-        if: matrix.job.cross_image
-        uses: docker/build-push-action@v2
+      - name: Setup cross build environment
+        uses: ./.github/workflows/setup-cross-build.yml
         with:
-          context: ci
-          file: ci/Dockerfile.${{ matrix.job.target }}-clang
-          tags: ${{ matrix.job.cross_image }}:latest
-          load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Install packages (macOS)
-        if: matrix.job.os == 'macos-latest'
-        run: |
-          ci/macos-install-packages.sh
-
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          targets: ${{ matrix.job.target }},"wasm32-unknown-unknown"
+          target: ${{ matrix.job.target }}
+          cross_image: ${{ matrix.job.cross_image }}
+          os: ${{ matrix.job.os }}
+          rust_version: ${{ env.RUST_VERSION }}
 
       - name: Install cargo-edit
         uses: actions-rs/cargo@v1

--- a/.github/workflows/setup-cross-build.yml
+++ b/.github/workflows/setup-cross-build.yml
@@ -1,0 +1,55 @@
+name: Setup Cross Build Environment
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+      cross_image:
+        required: false
+        type: string
+      os:
+        required: true
+        type: string
+      rust_version:
+        required: false
+        type: string
+        default: "stable"
+
+jobs:
+  setup:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout fuel-core for Docker files
+        if: inputs.cross_image
+        uses: actions/checkout@v3
+        with:
+          repository: fuellabs/fuel-core
+          path: fuel-core-ci
+
+      - name: Set up Docker Buildx
+        if: inputs.cross_image
+        uses: docker/setup-buildx-action@v1
+
+      - name: Setup custom cross env ${{ inputs.cross_image }}
+        if: inputs.cross_image
+        uses: docker/build-push-action@v2
+        with:
+          context: fuel-core-ci/ci
+          file: fuel-core-ci/ci/Dockerfile.${{ inputs.target }}-clang
+          tags: ${{ inputs.cross_image }}:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install packages (macOS)
+        if: contains(inputs.os, 'macos')
+        run: |
+          brew install llvm
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ inputs.rust_version }}
+          targets: ${{ inputs.target }},wasm32-unknown-unknown


### PR DESCRIPTION
Fixes build [failures ](https://github.com/FuelLabs/sway-nightly-binaries/actions/runs/17480050315) introduced by https://github.com/FuelLabs/sway/pull/7353 which added `fuel-core` as a dependency to the sway repo. We now have adopted `fuel-core`'s cross-compilation workflow to resolve `libclang` version conflicts and missing Rust target installations.

