### PR TITLE
fix composite action resolution by checking out repo first and building from sources

### DIFF
--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -83,11 +83,11 @@ jobs:
       - name: Checkout this repo (action path)
         uses: actions/checkout@v3
 
-      - name: Checkout sources
+      - name: Checkout sway
         uses: actions/checkout@v3
         with:
           repository: fuellabs/sway
-          path: sources
+          path: sway
 
       - name: Setup cross build environment
         uses: ./.github/actions/setup-cross-build
@@ -102,11 +102,11 @@ jobs:
           key: '${{ matrix.job.target }}'
 
       - name: Install cargo-edit
-        working-directory: sources
+        working-directory: sway
         run: cargo install cargo-edit
 
       - name: Bump patch version and add nightly pre-release tag
-        working-directory: sources
+        working-directory: sway
         run: |
           cargo set-version --metadata "nightly.${{ inputs.date }}.${{ needs.prepare-release.outputs.commit_hash }}"
 
@@ -117,7 +117,7 @@ jobs:
           cache-key: '${{ matrix.job.target }}'
 
       - name: Build forc binaries
-        working-directory: sources
+        working-directory: sway
         run: |
           cross build --profile=release --locked --target ${{ matrix.job.target }} --bins
 
@@ -127,7 +127,7 @@ jobs:
           PLATFORM_NAME: ${{ matrix.job.platform }}
           TARGET: ${{ matrix.job.target }}
           ARCH: ${{ matrix.job.arch }}
-        working-directory: sources
+        working-directory: sway
         run: |
           ZIP_FILE_NAME=${{ needs.prepare-release.outputs.zip_name }}-${{ env.PLATFORM_NAME }}_${{ env.ARCH }}.tar.gz
           echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -80,10 +80,14 @@ jobs:
             arch: arm64
             svm_target_platform: macosx-aarch64
     steps:
+      - name: Checkout this repo (action path)
+        uses: actions/checkout@v3
+
       - name: Checkout sources
         uses: actions/checkout@v3
         with:
           repository: fuellabs/sway
+          path: sources
 
       - name: Setup cross build environment
         uses: ./.github/actions/setup-cross-build
@@ -98,16 +102,13 @@ jobs:
           key: '${{ matrix.job.target }}'
 
       - name: Install cargo-edit
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-edit
+        working-directory: sources
+        run: cargo install cargo-edit
 
       - name: Bump patch version and add nightly pre-release tag
-        uses: actions-rs/cargo@v1
-        with:
-          command: set-version
-          args: --metadata nightly.${{ inputs.date }}.${{ needs.prepare-release.outputs.commit_hash }}
+        working-directory: sources
+        run: |
+          cargo set-version --metadata "nightly.${{ inputs.date }}.${{ needs.prepare-release.outputs.commit_hash }}"
 
       - name: Use Cross
         uses: baptiste0928/cargo-install@v1
@@ -116,6 +117,7 @@ jobs:
           cache-key: '${{ matrix.job.target }}'
 
       - name: Build forc binaries
+        working-directory: sources
         run: |
           cross build --profile=release --locked --target ${{ matrix.job.target }} --bins
 
@@ -125,6 +127,7 @@ jobs:
           PLATFORM_NAME: ${{ matrix.job.platform }}
           TARGET: ${{ matrix.job.target }}
           ARCH: ${{ matrix.job.arch }}
+        working-directory: sources
         run: |
           ZIP_FILE_NAME=${{ needs.prepare-release.outputs.zip_name }}-${{ env.PLATFORM_NAME }}_${{ env.ARCH }}.tar.gz
           echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -83,11 +83,11 @@ jobs:
       - name: Checkout this repo (action path)
         uses: actions/checkout@v3
 
-      - name: Checkout repository
+      - name: Checkout fuel-core
         uses: actions/checkout@v3
         with:
           repository: fuellabs/fuel-core
-          path: sources
+          path: fuel-core
 
       - name: Setup cross build environment
         uses: ./.github/actions/setup-cross-build
@@ -98,11 +98,11 @@ jobs:
           rust_version: ${{ env.RUST_VERSION }}
 
       - name: Install cargo-edit
-        working-directory: sources
+        working-directory: fuel-core
         run: cargo install cargo-edit
 
       - name: Bump patch version and add nightly pre-release tag
-        working-directory: sources
+        working-directory: fuel-core
         run: |
           cargo set-version --metadata "nightly.${{ inputs.date }}.${{ needs.prepare-release.outputs.commit_hash }}"
 
@@ -118,18 +118,18 @@ jobs:
           cache-key: '${{ matrix.job.target }}'
 
       - name: Build fuel-core
-        working-directory: sources
+        working-directory: fuel-core
         run: |
           cross build --profile=release --target ${{ matrix.job.target }} --features "production" -p fuel-core-bin
 
       - name: Strip release binary linux x86_64
         if: matrix.job.platform == 'linux'
-        working-directory: sources
+        working-directory: fuel-core
         run: strip "target/${{ matrix.job.target }}/release/fuel-core"
 
       - name: Strip release binary aarch64-linux-gnu
         if: matrix.job.target == 'aarch64-unknown-linux-gnu'
-        working-directory: sources
+        working-directory: fuel-core
         run: |
           docker run --rm -v \
           "$PWD/target:/target:Z" \
@@ -139,14 +139,14 @@ jobs:
 
       - name: Strip release binary mac
         if: matrix.job.os == 'macos-latest'
-        working-directory: sources
+        working-directory: fuel-core
         run: strip -x "target/${{ matrix.job.target }}/release/fuel-core"
 
       - name: Prepare Binary Artifact
         env:
           PLATFORM_NAME: ${{ matrix.job.platform }}
           TARGET: ${{ matrix.job.target }}
-        working-directory: sources
+        working-directory: fuel-core
         run: |
           ARTIFACT="${{ needs.prepare-release.outputs.zip_name }}-${{ env.TARGET }}"
           ZIP_FILE_NAME="$ARTIFACT.tar.gz"

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -80,10 +80,14 @@ jobs:
             platform: darwin-arm
             target: aarch64-apple-darwin
     steps:
+      - name: Checkout this repo (action path)
+        uses: actions/checkout@v3
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           repository: fuellabs/fuel-core
+          path: sources
 
       - name: Setup cross build environment
         uses: ./.github/actions/setup-cross-build
@@ -94,16 +98,13 @@ jobs:
           rust_version: ${{ env.RUST_VERSION }}
 
       - name: Install cargo-edit
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-edit
+        working-directory: sources
+        run: cargo install cargo-edit
 
       - name: Bump patch version and add nightly pre-release tag
-        uses: actions-rs/cargo@v1
-        with:
-          command: set-version
-          args: --metadata nightly.${{ inputs.date }}.${{ needs.prepare-release.outputs.commit_hash }}
+        working-directory: sources
+        run: |
+          cargo set-version --metadata "nightly.${{ inputs.date }}.${{ needs.prepare-release.outputs.commit_hash }}"
 
       - uses: Swatinem/rust-cache@v1
         with:
@@ -117,15 +118,18 @@ jobs:
           cache-key: '${{ matrix.job.target }}'
 
       - name: Build fuel-core
+        working-directory: sources
         run: |
           cross build --profile=release --target ${{ matrix.job.target }} --features "production" -p fuel-core-bin
 
       - name: Strip release binary linux x86_64
         if: matrix.job.platform == 'linux'
+        working-directory: sources
         run: strip "target/${{ matrix.job.target }}/release/fuel-core"
 
       - name: Strip release binary aarch64-linux-gnu
         if: matrix.job.target == 'aarch64-unknown-linux-gnu'
+        working-directory: sources
         run: |
           docker run --rm -v \
           "$PWD/target:/target:Z" \
@@ -135,12 +139,14 @@ jobs:
 
       - name: Strip release binary mac
         if: matrix.job.os == 'macos-latest'
+        working-directory: sources
         run: strip -x "target/${{ matrix.job.target }}/release/fuel-core"
 
       - name: Prepare Binary Artifact
         env:
           PLATFORM_NAME: ${{ matrix.job.platform }}
           TARGET: ${{ matrix.job.target }}
+        working-directory: sources
         run: |
           ARTIFACT="${{ needs.prepare-release.outputs.zip_name }}-${{ env.TARGET }}"
           ZIP_FILE_NAME="$ARTIFACT.tar.gz"


### PR DESCRIPTION
Nightly workflows failed with “Can’t find action.yml … Did you forget to run actions/checkout …” because the job checked out another repo over the workspace before calling the local composite action.

Fix: checkout this repo first (to provide ./.github/actions/setup-cross-build), then checkout the target repo into sources/, and call the composite via local path.