### PR TITLE
ci: setup-cross-build — add Cross.toml + Linux build deps

### DIFF
--- a/.github/actions/setup-cross-build/action.yml
+++ b/.github/actions/setup-cross-build/action.yml
@@ -43,6 +43,20 @@ runs:
         cache-from: type=gha,scope=cross-${{ inputs.target }}
         cache-to: type=gha,mode=max,scope=cross-${{ inputs.target }}
 
+    - name: Configure Cross.toml for custom image and extra deps
+      if: ${{ inputs.cross_image != '' }}
+      shell: bash
+      run: |
+        cat > Cross.toml <<'EOF'
+        [target.${{ inputs.target }}]
+        image = "${{ inputs.cross_image }}:latest"
+        pre-build = [
+          "apt-get update",
+          "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential pkg-config cmake libssl-dev zlib1g-dev"
+        ]
+        EOF
+        echo "CROSS_CONFIG=$PWD/Cross.toml" >> "$GITHUB_ENV"
+
     - name: Checkout fuel-core for macOS scripts
       if: ${{ runner.os == 'macOS' }}
       uses: actions/checkout@v3
@@ -59,6 +73,14 @@ runs:
         else
           brew install llvm
         fi
+
+    - name: Install packages (Linux native)
+      if: ${{ runner.os == 'Linux' && inputs.cross_image == '' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          build-essential clang libclang-dev pkg-config cmake libssl-dev zlib1g-dev
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/nightly-forc-release.yml
+++ b/.github/workflows/nightly-forc-release.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           cargo set-version --metadata "nightly.${{ inputs.date }}.${{ needs.prepare-release.outputs.commit_hash }}"
 
-      - name: Use Cross
+      - name: Install cross
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cross

--- a/.github/workflows/nightly-fuel-core-release.yml
+++ b/.github/workflows/nightly-fuel-core-release.yml
@@ -15,7 +15,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.81.0
+  RUST_VERSION: 1.86.0
 
 jobs:
   prepare-release:


### PR DESCRIPTION
Making progress but running into new [failures](https://github.com/FuelLabs/sway-nightly-binaries/actions/runs/17541292686/job/49813366875) which this PR aims to address. 

overview:
- Install build-essential/clang/libclang-dev/pkg-config/cmake/libssl-dev/zlib1g-dev (native Linux and via Cross.toml pre-build) so libc headers and modern libclang are available.
- Fixes librocksdb-sys/clang-sys failures (stdarg.h missing, libclang 3.8.x).
- bumps rust version from 1.81 to 1.86 for fuel-core to [match](https://github.com/FuelLabs/fuel-core/blob/33238c6e10b0d72fd4f490c854afa414adef1f02/Cargo.toml#L53C1-L53C24) their repo 